### PR TITLE
bug fix terminology order difference between src and tar

### DIFF
--- a/evaluate_term_wmt.py
+++ b/evaluate_term_wmt.py
@@ -37,11 +37,11 @@ def read_reference_data_wmt(lt, ls):
 			terms = []
 			terms_l = []
 			mod_terms = []
-			src_terms = soups.find_all('term')
 			tgt_terms = soupt.find_all('term')
 			for ids, item in enumerate(tgt_terms):
-				src_start = source_tokens.index(src_terms[ids].text.split()[0])
-				src_end = source_tokens.index(src_terms[ids].text.split()[-1])
+				src_term = soups.find('term', id=item['id'])
+				src_start = source_tokens.index(src_term.text.split()[0])
+				src_end = source_tokens.index(src_term.text.split()[-1])
 				src_ids = ""
 				for ind in range(src_start, src_end - 1):
 					src_ids += (str)(ind) + ","
@@ -57,15 +57,15 @@ def read_reference_data_wmt(lt, ls):
 				tgt_term = item['tgt']
 				if item.text.strip() not in tgt_term:
 					tgt_term = item['tgt'] + "|" + item.text.strip()
-				mod_terms.append(f"{src_terms[ids].text} ||| {src_ids} --> {tgt_term} ||| {tgt_ids}")
+				mod_terms.append(f"{src_term.text} ||| {src_ids} --> {tgt_term} ||| {tgt_ids}")
 
 				if "tgt_original" in tgt_terms[ids]['type']:
-					terms.append(f"{src_terms[ids].text} ||| {src_ids} --> {tgt_terms[ids].text} ||| {tgt_ids}")
+					terms.append(f"{src_term.text} ||| {src_ids} --> {tgt_terms[ids].text} ||| {tgt_ids}")
 				if "tgt_lemma" in tgt_terms[ids]['type']:
 					if SUPPORTED:
 						doc_f = l2_stanza(tgt_terms[ids].text)
 						tgt_lemma = ' ' + ' '.join([w.lemma for w in doc_f.sentences[0].words]) + ' '
-						terms_l.append(f"{src_terms[ids].text} ||| {src_ids} --> {tgt_lemma} ||| {tgt_ids}")
+						terms_l.append(f"{src_term.text} ||| {src_ids} --> {tgt_lemma} ||| {tgt_ids}")
 			refs[id] = (source, target, terms, terms_l, mod_terms)
 
 	return sources, outputs, refs


### PR DESCRIPTION
The implementation of `read_wmt_reference_data` assumes that the terminologies appear in the same order in both source and target which is often not the case (not even for EN-FR).

This leads to wrong attribution of terminologies like in this example:

![bug_data_loader](https://user-images.githubusercontent.com/50372080/171025089-236b60f9-fbd5-4118-a353-f7633122c6d2.png)

as the original implementation just uses the `ids` from the enumerate call, instead the correct source term needs to be extraced using the `id` field of the `term` tag as implemented.

In this branch I extract the correct src_term by term id.